### PR TITLE
ci: Upgrade GHA actions and Node.js to v24

### DIFF
--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -10,13 +10,13 @@ jobs:
   test:
     runs-on: Ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{github.event.pull_request.head.sha}}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- `actions/checkout` を v4 → v6 に更新
- `actions/setup-node` を v4 → v6 に更新
- `node-version` を 20 → 24 に更新

## Test plan

- [x] PR作成後、GitHub Actions の unit test ワークフローが Node.js 24 で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)